### PR TITLE
Add OTP (email one-time code) registration option

### DIFF
--- a/app/controllers/otp_registrations_controller.rb
+++ b/app/controllers/otp_registrations_controller.rb
@@ -1,0 +1,78 @@
+class OtpRegistrationsController < ApplicationController
+  # Step 1: user submitted an email from the OTP tab on the sign-up screen.
+  # We always respond the same way (redirect to the verify step) regardless of
+  # whether the email already has an account, to avoid leaking which emails
+  # exist. If it does exist we quietly send a normal *login* code, so verifying
+  # just signs that user in; otherwise we send a *registration* code and keep
+  # the pending registration in the session until it's verified.
+  def create
+    email = params[:email].to_s.strip.downcase
+
+    if (user = User.find_by(email: email))
+      code = user.generate_otp!
+      OtpMailer.login_code(user.id, code).deliver_later
+    else
+      code = User.generate_otp_code
+      session[:reg_otp_digest]  = User.otp_digest(code)
+      session[:reg_otp_sent_at] = Time.current.iso8601
+      OtpMailer.registration_code(email, code).deliver_later
+    end
+
+    session[:reg_otp_email] = email
+    # _url (not _path) so the redirect keeps the public :46580 port behind the
+    # reverse proxy — see default_url_options in ApplicationController.
+    redirect_to user_otp_register_verify_url, notice: t(:'devise.otp_register_sent')
+  end
+
+  # Step 2 (GET): render the code-entry form.
+  def verify
+    return redirect_to new_user_registration_url if session[:reg_otp_email].blank?
+
+    @email = session[:reg_otp_email]
+  end
+
+  # Step 2 (POST): verify the submitted code, then either create the account
+  # (new email) or sign the existing user in (email already registered).
+  def confirm
+    email = session[:reg_otp_email]
+    user  = User.find_by(email: email)
+
+    if user
+      ok = user.verify_otp(params[:otp_code])
+      user.clear_otp! if ok
+    else
+      sent_at = session[:reg_otp_sent_at] && Time.zone.parse(session[:reg_otp_sent_at])
+      ok = User.otp_valid?(session[:reg_otp_digest], sent_at, params[:otp_code])
+      user = create_otp_user(email) if ok
+    end
+
+    if ok && user
+      clear_reg_otp_session
+      # Set remember_me before sign_in so Devise's rememberable hook drops the
+      # remember cookie, matching the password form (which always remembers).
+      user.remember_me = true
+      sign_in(user)
+      redirect_to after_sign_in_path_for(user), notice: t(:'devise.otp_registered')
+    else
+      flash.now[:alert] = t(:'devise.otp_invalid')
+      @email = email
+      render :verify, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  # OTP-registered users get an unguessable random password (Devise's
+  # :validatable requires one). They sign in via OTP going forward, or set a
+  # real password later through the "forgot password" flow.
+  def create_otp_user(email)
+    pw = Devise.friendly_token(32)
+    User.create!(email: email, password: pw, password_confirmation: pw)
+  end
+
+  def clear_reg_otp_session
+    session.delete(:reg_otp_email)
+    session.delete(:reg_otp_digest)
+    session.delete(:reg_otp_sent_at)
+  end
+end

--- a/app/mailers/otp_mailer.rb
+++ b/app/mailers/otp_mailer.rb
@@ -12,4 +12,15 @@ class OtpMailer < ApplicationMailer
       format.text
     end
   end
+
+  # Registration code is sent before the account exists, so it takes the raw
+  # email rather than a user id.
+  def registration_code(email, code)
+    @code = code
+
+    mail(to: email, subject: "Tvoj registračný kód") do |format|
+      format.html
+      format.text
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,19 +7,35 @@ class User < ApplicationRecord
 
   OTP_VALIDITY = 10.minutes
 
+  # A fresh 6-digit code, zero-padded. Returned in plaintext to be emailed.
+  def self.generate_otp_code
+    format("%06d", SecureRandom.random_number(1_000_000))
+  end
+
+  def self.otp_digest(code)
+    Digest::SHA256.hexdigest(code.to_s)
+  end
+
+  # Constant-time check of a submitted code against a stored digest + timestamp.
+  # The digest/sent_at can come from a persisted row (login) or from the session
+  # (a pending OTP registration where no row exists yet).
+  def self.otp_valid?(digest, sent_at, submitted)
+    return false if digest.blank? || sent_at.blank?
+    return false if sent_at < OTP_VALIDITY.ago
+
+    Devise.secure_compare(digest, otp_digest(submitted))
+  end
+
   # Generates a fresh 6-digit login code, stores only its digest, and returns
   # the plaintext so the caller can email it. The plaintext is never persisted.
   def generate_otp!
-    code = format("%06d", SecureRandom.random_number(1_000_000))
-    update!(otp_code_digest: Digest::SHA256.hexdigest(code), otp_sent_at: Time.current)
+    code = self.class.generate_otp_code
+    update!(otp_code_digest: self.class.otp_digest(code), otp_sent_at: Time.current)
     code
   end
 
   def verify_otp(submitted)
-    return false if otp_code_digest.blank? || otp_sent_at.blank?
-    return false if otp_sent_at < OTP_VALIDITY.ago
-
-    Devise.secure_compare(otp_code_digest, Digest::SHA256.hexdigest(submitted.to_s))
+    self.class.otp_valid?(otp_code_digest, otp_sent_at, submitted)
   end
 
   def clear_otp!

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,37 +1,76 @@
-<div class="max-w-sm mx-auto py-8">
+<div class="max-w-sm mx-auto py-8" data-controller="tabs">
   <h1 class="text-3xl font-medium tracking-tight mb-8 text-center">
     <%= t(:'devise.signup') %>
   </h1>
 
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
+  <div class="panel-inset p-1 grid grid-cols-2 gap-1 mb-8">
+    <button type="button"
+            data-tabs-target="tab"
+            data-action="tabs#show"
+            data-key="password"
+            class="px-3 py-2 rounded text-sm text-text-dim hover:text-text
+                   transition-colors active text-text bg-surface">
+      <%= t(:'devise.password_tab') %>
+    </button>
+    <button type="button"
+            data-tabs-target="tab"
+            data-action="tabs#show"
+            data-key="otp"
+            class="px-3 py-2 rounded text-sm text-text-dim hover:text-text
+                   transition-colors">
+      <%= t(:'devise.otp_register_tab') %>
+    </button>
+  </div>
 
-    <div class="space-y-5">
-      <div>
+  <%# ─── Password registration (legacy) ─── %>
+  <div data-tabs-target="panel" data-key="password">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="space-y-5">
+        <div>
+          <%= f.label :email, class: "label" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input" %>
+        </div>
+
+        <div>
+          <%= f.label t(:'devise.password'), class: "label" %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "input" %>
+          <% if @minimum_password_length %>
+            <div class="mt-1.5 text-xs text-text-mute font-mono">
+              <%= "#{@minimum_password_length} #{t(:'devise.minimum_characters')}" %>
+            </div>
+          <% end %>
+        </div>
+
+        <div>
+          <%= f.label t(:'devise.password_confirmation'), class: "label" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input" %>
+        </div>
+      </div>
+
+      <div class="mt-8 flex flex-col gap-3">
+        <%= f.submit t(:'devise.signup_btn'), class: "btn-primary justify-center cursor-pointer w-full" %>
+        <%= link_to t(:'devise.already_have_account'), new_user_session_path,
+            class: "text-sm text-text-dim hover:text-text transition-colors text-center" %>
+      </div>
+    <% end %>
+  </div>
+
+  <%# ─── OTP registration (one-time code by e-mail) ─── %>
+  <div data-tabs-target="panel" data-key="otp" class="hidden">
+    <%= form_with url: user_otp_register_request_path, method: :post do |f| %>
+      <div class="space-y-2">
         <%= f.label :email, class: "label" %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input" %>
+        <%= f.email_field :email, autocomplete: "email", class: "input" %>
+        <p class="text-sm text-text-dim"><%= t(:'devise.otp_register_email_prompt') %></p>
       </div>
 
-      <div>
-        <%= f.label t(:'devise.password'), class: "label" %>
-        <%= f.password_field :password, autocomplete: "new-password", class: "input" %>
-        <% if @minimum_password_length %>
-          <div class="mt-1.5 text-xs text-text-mute font-mono">
-            <%= "#{@minimum_password_length} #{t(:'devise.minimum_characters')}" %>
-          </div>
-        <% end %>
+      <div class="mt-8 flex flex-col gap-3">
+        <%= f.submit t(:'devise.otp_register_send_btn'), class: "btn-primary justify-center cursor-pointer w-full" %>
+        <%= link_to t(:'devise.already_have_account'), new_user_session_path,
+            class: "text-sm text-text-dim hover:text-text transition-colors text-center" %>
       </div>
-
-      <div>
-        <%= f.label t(:'devise.password_confirmation'), class: "label" %>
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input" %>
-      </div>
-    </div>
-
-    <div class="mt-8 flex flex-col gap-3">
-      <%= f.submit t(:'devise.signup_btn'), class: "btn-primary justify-center cursor-pointer w-full" %>
-      <%= link_to t(:'devise.already_have_account'), new_user_session_path,
-          class: "text-sm text-text-dim hover:text-text transition-colors text-center" %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/otp_mailer/registration_code.html.erb
+++ b/app/views/otp_mailer/registration_code.html.erb
@@ -1,0 +1,19 @@
+<p style="margin:0 0 16px; font-size:16px; color:#0a0a0a;">
+  Ahoj,
+</p>
+
+<p style="margin:0 0 24px; font-size:15px; color:#3a3a3a;">
+  Tu je tvoj registračný kód:
+</p>
+
+<div style="margin:0 0 24px; padding:20px; text-align:center;
+            background:#f5f5f5; border:1px solid #e5e5e5; border-radius:8px;">
+  <span style="font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+               font-size:34px; letter-spacing:8px; font-weight:600; color:#0a0a0a;">
+    <%= @code %>
+  </span>
+</div>
+
+<p style="margin:0; font-size:13px; color:#6b6b6b;">
+  Kód platí 10 minút. Ak si o registráciu nežiadal/a, tento e-mail ignoruj.
+</p>

--- a/app/views/otp_mailer/registration_code.text.erb
+++ b/app/views/otp_mailer/registration_code.text.erb
@@ -1,0 +1,7 @@
+Ahoj,
+
+Tu je tvoj registračný kód:
+
+    <%= @code %>
+
+Kód platí 10 minút. Ak si o registráciu nežiadal/a, tento e-mail ignoruj.

--- a/app/views/otp_registrations/verify.html.erb
+++ b/app/views/otp_registrations/verify.html.erb
@@ -1,0 +1,23 @@
+<div class="max-w-sm mx-auto py-8">
+  <h1 class="text-3xl font-medium tracking-tight mb-2 text-center">
+    <%= t(:'devise.signup') %>
+  </h1>
+  <p class="text-sm text-text-dim text-center mb-8">
+    <%= t(:'devise.otp_code_prompt', email: @email) %>
+  </p>
+
+  <%= form_with url: user_otp_register_verify_path, method: :post do |f| %>
+    <div>
+      <%= f.label :otp_code, t(:'devise.otp_code'), class: "label" %>
+      <%= f.text_field :otp_code, autofocus: true, autocomplete: "one-time-code",
+          inputmode: "numeric", pattern: "[0-9]*", maxlength: 6,
+          class: "input text-center tracking-[0.5em] font-mono text-xl" %>
+    </div>
+
+    <div class="mt-8 flex flex-col gap-3">
+      <%= f.submit t(:'devise.otp_verify_btn'), class: "btn-primary justify-center cursor-pointer w-full" %>
+      <%= link_to t(:'devise.otp_request_new'), new_user_registration_path,
+          class: "text-sm text-text-dim hover:text-text transition-colors text-center" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,11 @@ en:
     otp_sent: "If an account with that email exists, we've sent it a login code."
     otp_invalid: "Invalid or expired code."
     otp_signed_in: "Signed in successfully."
+    otp_register_tab: "One-time code"
+    otp_register_email_prompt: "We'll email you a code to create your account."
+    otp_register_send_btn: "Send code"
+    otp_register_sent: "We've sent a code to your email."
+    otp_registered: "Account created — you're signed in."
   header:
     overview: "Overview"
     edit_profile: "Edit profile"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -61,6 +61,11 @@ sk:
     otp_sent: "Ak účet s týmto e-mailom existuje, poslali sme naň prihlasovací kód."
     otp_invalid: "Neplatný alebo expirovaný kód."
     otp_signed_in: "Úspešne prihlásený."
+    otp_register_tab: "Jednorazový kód"
+    otp_register_email_prompt: "Pošleme ti na e-mail kód na vytvorenie účtu."
+    otp_register_send_btn: "Poslať kód"
+    otp_register_sent: "Poslali sme ti na e-mail kód."
+    otp_registered: "Účet bol vytvorený — si prihlásený."
   header:
     overview: "Prehľad"
     edit_profile: "Upraviť profil"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     post "users/otp",        to: "otp_sessions#create",  as: :user_otp_request
     get  "users/otp/verify", to: "otp_sessions#verify",  as: :user_otp_verify
     post "users/otp/verify", to: "otp_sessions#confirm",  as: :user_otp_confirm
+
+    post "users/otp/register",        to: "otp_registrations#create",  as: :user_otp_register_request
+    get  "users/otp/register/verify", to: "otp_registrations#verify",  as: :user_otp_register_verify
+    post "users/otp/register/verify", to: "otp_registrations#confirm",  as: :user_otp_register_confirm
   end
 
   authenticate :user, ->(user) { user.is_admin? } do


### PR DESCRIPTION
Mirrors the existing OTP login flow on the sign-up page. New users can create an account with just an email + a one-time code; the pending OTP lives in the session (no schema change, no phantom rows) until verified, then the account is created with a random unguessable password (Devise :validatable requires one). OTP-registered users sign in via OTP, or set a password later through the existing "forgot password" flow.

If the submitted email is already registered, a normal login code is sent instead, so verifying just signs that user in. The request step responds identically for new vs. existing emails to avoid leaking which exist.