### PR TITLE
Deliver Devise emails asynchronously to fix hanging reset form

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,4 +41,13 @@ class User < ApplicationRecord
   def clear_otp!
     update!(otp_code_digest: nil, otp_sent_at: nil)
   end
+
+  # Devise delivers its notifications (password reset, password/email change)
+  # synchronously by default, which blocks the request on the slow Gmail SMTP
+  # handshake — the reset form would hang in the browser until the send
+  # finished. Enqueue through Active Job / Sidekiq instead, matching the rest
+  # of the app (OtpMailer, FetcherAlertMailer all use deliver_later).
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
 end


### PR DESCRIPTION
Devise sends its notifications (password reset, password/email change) with deliver_now by default, so PasswordsController#create blocked the request on the slow Gmail SMTP handshake — the reset form hung in the browser until the send completed, even though the email went out fine.

Override send_devise_notification on User to use deliver_later, matching the rest of the app (OtpMailer, FetcherAlertMailer). Active Job is already on the :sidekiq adapter with a mailers queue, so the POST now returns immediately and Sidekiq delivers the mail.